### PR TITLE
Unused params in commitSync

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -265,7 +265,7 @@ Repository.prototype.commit = function(message, callback) {
  * Commits the staged area with the given message
  * @param  {String}   message
  */
-Repository.prototype.commitSync = function(message, callback, useSync) {
+Repository.prototype.commitSync = function(message) {
   var self   = this;
   var cmd    = new Command(this.path, 'commit', ['-m'], '"' + message + '"');
   var output = cmd.execSync()


### PR DESCRIPTION
Unused params in commitSync. Probably just some mistake because callback in sync method? naaaah...