### PR TITLE
Switching the order of logFmt and branch in logSync

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -105,7 +105,7 @@ Repository.prototype.log = function() {
  */
 Repository.prototype.logSync = function(branch) {
   var self = this;
-  var cmd  = new Command(self.path, 'log', [branch || '', logFmt]);
+  var cmd  = new Command(self.path, 'log', [logFmt, branch || '']);
 
   return parse.log(cmd.execSync());
 };


### PR DESCRIPTION
In Git 1.9.1, if the --pretty flag is after the directory/filename, git throws an error saying that the --pretty flag is in the wrong place. Instead of git handling it by itself, it decides to throw an error. Switching logFmt and the branch argument around fixes this issue on logSync. I used logSync to get the log of a specific directory and noticed this issue.