### PR TITLE
Adding the ability to use git show to see the revision of a specific file

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -784,6 +784,39 @@ Repository.prototype.cherryPickSync = function(commit) {
 };
 
 /**
+ * Allows show
+ * @param  {string}   commit   Commit string
+ * @param  {string}   filePath Full path of the file relative to the repo
+ * @param  {Function} callback callback-function
+ */
+Repository.prototype.show = function(commit, filePath, callback) {
+  var self = this;
+  var done = callback || new Function();
+  var revision = commit + ':' + filePath;
+  var cmd  = new Command(self.path, 'show', [], revision);
+
+  cmd.exec(function(err, stdout, stderr) {
+    if (err) {
+      return done(err);
+    }
+    done(null, stdout);
+  });
+};
+
+/**
+ * Allows show
+ * @param  {string}   commit   Commit string
+ * @param  {string}   filePath Full path of the file relative to the repo
+ */
+Repository.prototype.showSync = function(commit, filePath) {
+  var self = this;
+  var revision = commit + ':' + filePath;
+  var cmd  = new Command(self.path, 'show', [], revision);
+
+  return cmd.execSync();
+};
+
+/**
  * Export Constructor
  * @type {Object}
  */

--- a/test/repository.integration.js
+++ b/test/repository.integration.js
@@ -602,4 +602,51 @@ describe('Repository', function() {
 
   });
 
+  describe('.show()', function() {
+
+    it('should return a specific revision of a file from a commit ID', function(done) {
+      fs.writeFile(repo1.path + '/show.txt', 'showTest rev 1', function(err) {
+        repo1.add([repo1.path + '/show.txt'], function(err) {
+          repo1.commit('showTest', function(err) {
+            fs.writeFile(repo1.path + '/show.txt', 'showTest rev 2', function(err) {
+              repo1.add([repo1.path + '/show.txt'], function(err) {
+                repo1.commit('showTest change', function(err) {
+                  repo1.log(function(err, log) {
+                    repo1.show(log[1].commit, './show.txt', function(err, data) {
+                      data.should.equal('showTest rev 1');
+                      done();
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
+  });
+
+  describe('.showSync()', function() {
+
+    it('should return a specific revision of a file from a commit ID', function(done) {
+      repo2.checkoutSync('test');
+
+      fs.writeFileSync('show.txt', 'showTest rev 1');
+      repo2.addSync(['show.txt']);
+      repo2.commitSync('showTest');
+
+      fs.writeFileSync('show.txt', 'showTest rev 2');
+      repo2.addSync(['show.txt']);
+      repo2.commitSync('showTest change');
+
+      var log = repo2.logSync();
+      var testText = repo2.showSync(log[1].commit, './show.txt');
+
+      testText.should.equal('showTest rev 1');
+      done();
+    });
+
+  });
+
 });


### PR DESCRIPTION
Git show was missing from the list of git commands. I added it in along with the tests and the synchronous version. Git show allows you to view a revision of a file on a commit ID. There's a bit of a problem with error handling, since git show doesn't actually throw an error code, it just prints out a string if the path doesn't exist in that commit. So I left it for the user to filter that out. Git responds with a string containing: "fatal: path 'xxx' does not exist in 'xxx'\n ".