### PR TITLE
Fix ENOBUFS

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -24,7 +24,8 @@ var Command = function(path, operation, flags, options) {
   // The log on long lived active repos will require more stdout buffer.
   // The default (200K) seems sufficient for all other operations.
   this.execBuffer = 1024 * 200;
-  if(largeOperations.indexOf(operation) > -1) {
+
+  if (largeOperations.indexOf(operation) > -1) {
     this.execBuffer = 1024 * 5000;
   }
 };

--- a/lib/command.js
+++ b/lib/command.js
@@ -17,12 +17,16 @@ var execSync = childproc.execSync;
 var Command = function(path, operation, flags, options) {
   flags = flags || [];
   options = options || '';
+  var largeOperations = ['log', 'ls-files'];
 
   this.repo = path;
   this.command = 'git ' + operation + ' ' + flags.join(' ') + ' ' + options;
   // The log on long lived active repos will require more stdout buffer.
   // The default (200K) seems sufficient for all other operations.
-  this.execBuffer = operation === 'log' ? 1024 * 5000 : 1024 * 200;
+  this.execBuffer = 1024 * 200;
+  if(largeOperations.indexOf(operation) > -1) {
+    this.execBuffer = 1024 * 5000;
+  }
 };
 
 /**

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -100,7 +100,7 @@ parsers.commit = function(output) {
           if (lines[ln].indexOf('#') === -1) {
             return lines[ln];
           }
-        };
+        }
       })(output)
     };
   }

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -9,7 +9,7 @@ var Command = require('./command');
 var parse = require('./parser');
 var events = require('events');
 var logFmt = '--pretty=format:\'{"commit":"%H","author":"%an <%ae>",' +
-             '"date":"%ad","message":"%s"},\''
+             '"date":"%ad","message":"%s"},\'';
 
 /**
 * Constructor function for all repository commands
@@ -45,8 +45,8 @@ Repository.prototype.init = function() {
   var self = this;
   var args = Array.prototype.slice.apply(arguments);
   var flags = Array.isArray(args[0]) ? args[0] : [];
-  var done = args.slice(-1).pop() || new Function();
-  var cmd = new Command(self.path, 'init', flags, '')
+  var done = args.slice(-1).pop() || function() { };
+  var cmd = new Command(self.path, 'init', flags, '');
 
   cmd.exec(function(err, stdout, stderr) {
     if (err) {
@@ -69,7 +69,7 @@ Repository.prototype.initSync = function() {
   var self = this;
   var args = Array.prototype.slice.apply(arguments);
   var flags = Array.isArray(args[0]) ? args[0] : [];
-  var cmd = new Command(self.path, 'init', flags, '')
+  var cmd = new Command(self.path, 'init', flags, '');
 
   cmd.execSync();
 
@@ -86,7 +86,7 @@ Repository.prototype.log = function() {
   var self = this;
   var args = Array.prototype.slice.apply(arguments);
   var path = typeof args[0] === 'string' ? args[0] : '';
-  var done = args.slice(-1).pop() || new Function();
+  var done = args.slice(-1).pop() || function() { };
   var cmd = new Command(self.path, 'log', [logFmt, path]);
 
   cmd.exec(function(err, stdout, stderr) {
@@ -117,7 +117,7 @@ Repository.prototype.logSync = function(branch) {
 */
 Repository.prototype.status = function(callback) {
   var self = this;
-  var done = callback || new Function();
+  var done = callback || function() { };
   var status = new Command(self.path, 'status');
   var lsFiles = new Command(self.path, 'ls-files', ['-o','--exclude-standard']);
 
@@ -156,7 +156,7 @@ Repository.prototype.statusSync = function() {
 */
 Repository.prototype.add = function(files, callback) {
   var self = this;
-  var done = callback || new Function();
+  var done = callback || function() { };
   var cmd = new Command(self.path, 'add', [], files.join(' '));
 
   cmd.exec(function(err, stdout, stderr) {
@@ -188,7 +188,7 @@ Repository.prototype.addSync = function(files) {
 */
 Repository.prototype.remove = function(files, callback) {
   var self = this;
-  var done = callback || new Function();
+  var done = callback || function() { };
   var cmd = new Command(self.path, 'rm', ['--cached'], files.join(' '));
 
   cmd.exec(function(err, stdout, stderr) {
@@ -220,7 +220,7 @@ Repository.prototype.removeSync = function(files) {
 */
 Repository.prototype.unstage = function(files, callback) {
   var self = this;
-  var done = callback || new Function();
+  var done = callback || function() { };
   var cmd = new Command(self.path, 'reset HEAD', [], files.join(' '));
 
   cmd.exec(function(err, stdout, stderr) {
@@ -252,7 +252,7 @@ Repository.prototype.unstageSync = function(files) {
 */
 Repository.prototype.commit = function(message, callback) {
   var self = this;
-  var done = callback || new Function();
+  var done = callback || function() { };
   var cmd = new Command(this.path, 'commit', ['-m'], '"' + message + '"');
 
   cmd.exec(function(err, stdout, stderr) {
@@ -278,8 +278,8 @@ Repository.prototype.commit = function(message, callback) {
 Repository.prototype.commitSync = function(message) {
   var self = this;
   var cmd = new Command(this.path, 'commit', ['-m'], '"' + message + '"');
-  var output = cmd.execSync()
-  var result = output ? parse.commit(output) : {}
+  var output = cmd.execSync();
+  var result = output ? parse.commit(output) : {};
 
   if (result.error) {
     throw new Error(result.error);
@@ -295,7 +295,7 @@ Repository.prototype.commitSync = function(message) {
 */
 Repository.prototype.getBranches = function(callback) {
   var self = this;
-  var done = callback || new Function();
+  var done = callback || function() { };
   var cmd = new Command(self.path, 'branch');
 
   cmd.exec(function(err, stdout, stderr) {
@@ -327,7 +327,7 @@ Repository.prototype.getBranchesSync = function() {
 */
 Repository.prototype.createBranch = function(name, callback) {
   var self = this;
-  var done = callback || new Function();
+  var done = callback || function() { };
   var cmd = new Command(self.path, 'branch', [], name);
 
   cmd.exec(function(err, stdout, stderr) {
@@ -359,7 +359,7 @@ Repository.prototype.createBranchSync = function(name) {
 */
 Repository.prototype.checkout = function(branch, callback) {
   var self = this;
-  var done = callback || new Function();
+  var done = callback || function() { };
   var cmd = new Command(self.path, 'checkout', [], branch);
 
   cmd.exec(function(err, stdout, stderr) {
@@ -393,7 +393,7 @@ Repository.prototype.checkoutSync = function(branch) {
 */
 Repository.prototype.merge = function(branch, callback) {
   var self = this;
-  var done = callback || new Function();
+  var done = callback || function() { };
   var cmd = new Command(self.path, 'merge', [], branch);
 
   cmd.exec(function(err, stdout, stderr) {
@@ -424,7 +424,7 @@ Repository.prototype.mergeSync = function(branch) {
 */
 Repository.prototype.getTags = function(callback) {
   var self = this;
-  var done = callback || new Function();
+  var done = callback || function() { };
   var cmd = new Command(self.path, 'tag');
 
   cmd.exec(function(err, stdout, stderr) {
@@ -455,8 +455,8 @@ Repository.prototype.getTagsSync = function() {
 */
 Repository.prototype.createTag = function(name, callback) {
   var self = this;
-  var done = callback || new Function();
-  var cmd = new Command(self.path, 'tag', [], name)
+  var done = callback || function() { };
+  var cmd = new Command(self.path, 'tag', [], name);
 
   cmd.exec(function(err, stdout, stderr) {
     if (err) {
@@ -474,7 +474,7 @@ Repository.prototype.createTag = function(name, callback) {
 */
 Repository.prototype.createTagSync = function(name) {
   var self = this;
-  var cmd = new Command(self.path, 'tag', [], name)
+  var cmd = new Command(self.path, 'tag', [], name);
 
   return cmd.execSync();
 };
@@ -488,7 +488,7 @@ Repository.prototype.createTagSync = function(name) {
 */
 Repository.prototype.addRemote = function(remote, url, callback) {
   var self = this;
-  var done = callback || new Function();
+  var done = callback || function() { };
   var cmd = new Command(self.path, 'remote add', [], remote + ' ' + url);
 
   cmd.exec(function(err, stdout, stderr) {
@@ -522,7 +522,7 @@ Repository.prototype.addRemoteSync = function(remote, url) {
 */
 Repository.prototype.setRemoteUrl = function(remote, url, callback) {
   var self = this;
-  var done = callback || new Function();
+  var done = callback || function() { };
   var cmd = new Command(self.path, 'remote set-url', [], remote + ' ' + url);
 
   cmd.exec(function(err, stdout, stderr) {
@@ -556,7 +556,7 @@ Repository.prototype.setRemoteUrlSync = function(remote, url) {
 */
 Repository.prototype.removeRemote = function(remote, callback) {
   var self = this;
-  var done = callback || new Function();
+  var done = callback || function() { };
   var cmd = new Command(self.path, 'remote rm', [], remote);
 
   cmd.exec(function(err, stdout, stderr) {
@@ -587,7 +587,7 @@ Repository.prototype.removeRemoteSync = function(remote) {
 */
 Repository.prototype.getRemotes = function(callback) {
   var self = this;
-  var done = callback || new Function();
+  var done = callback || function() { };
   var cmd = new Command(self.path, 'remote', ['-v']);
 
   cmd.exec(function(err, stdout, stderr) {
@@ -686,16 +686,16 @@ Repository.prototype.pull = function() {
 */
 function sync(path, opts, callback) {
   var self = this;
-  var done = callback || new Function();
+  var done = callback || function() { };
   var flags = opts.flags || [];
   var creds = opts.credentials;
-  var options = [opts.remote, opts.branch].concat(flags)
+  var options = [opts.remote, opts.branch].concat(flags);
   var cmd = new Command(self.path, opts.operation, options);
 
   cmd.exec(function(err, stdout, stderr) {
     done(err);
   });
-};
+}
 
 /**
 * Resets the repository's HEAD to the specified commit
@@ -705,7 +705,7 @@ function sync(path, opts, callback) {
 */
 Repository.prototype.reset = function(hash, callback) {
   var self = this;
-  var done = callback || new Function();
+  var done = callback || function() { };
   var cmd = new Command(self.path, 'reset', ['--hard'], hash);
 
   cmd.exec(function(err, stdout, stderr) {
@@ -734,7 +734,7 @@ Repository.prototype.resetSync = function(hash) {
 
   cmd.execSync();
 
-  return self.logSync()
+  return self.logSync();
 };
 
 /**
@@ -744,7 +744,7 @@ Repository.prototype.resetSync = function(hash) {
 */
 Repository.prototype.describe = function(callback) {
   var self = this;
-  var done = callback || new Function();
+  var done = callback || function() { };
   var cmd = new Command(self.path, 'describe', ['--always']);
 
   cmd.exec(function(err, stdout, stderr) {
@@ -775,7 +775,7 @@ Repository.prototype.describeSync = function() {
 */
 Repository.prototype.cherryPick = function(commit, callback) {
   var self = this;
-  var done = callback || new Function();
+  var done = callback || function() { };
   var cmd  = new Command(self.path, 'cherry-pick', [], commit);
 
   cmd.exec(function(err, stdout, stderr) {
@@ -809,7 +809,7 @@ Repository.prototype.cherryPickSync = function(commit) {
 */
 Repository.prototype.show = function(commit, filePath, callback) {
   var self = this;
-  var done = callback || new Function();
+  var done = callback || function() { };
   var revision = commit + ':' + filePath;
   var cmd  = new Command(self.path, 'show', [], revision);
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,10 @@
     {
       "name": "Nicolas Chambrier",
       "url": "http://naholyr.fr"
+    },
+    {
+      "name": "Victor Gama",
+      "url": "http://vito.io"
     }
   ],
   "license": "LGPLv3"

--- a/test/gitty.integration.js
+++ b/test/gitty.integration.js
@@ -99,4 +99,4 @@ describe('Gitty', function() {
 
   });
 
-})
+});

--- a/test/repository.integration.js
+++ b/test/repository.integration.js
@@ -323,7 +323,7 @@ describe('Repository', function() {
               repo1.log(function(err, log) {
                 log.should.have.lengthOf(2);
                 done();
-              })
+              });
             });
           });
         });
@@ -516,7 +516,7 @@ describe('Repository', function() {
         repo1.log(function(err, log) {
           log[0].commit.substr(0, 7).should.equal(hash.substr(0, 7));
           done();
-        })
+        });
       });
     });
 


### PR DESCRIPTION
After some investigations I noticed a gitty call was throwing `ENOBUFS`[0] when `statusSync` was invoked. The reason is that 200K was not sufficient to hold the output of `git ls-files`. This pull request addresses this issue by increasing the buffer size when the operation is `log` or `ls-files`.

I had to break your ternary operation to respect the 80-columns convention.

Thank you for this great library!

[0]: Error and stack:
```
child_process.js:1364
    throw err;
          ^
Error: spawnSync /bin/sh ENOBUFS
    at exports._errnoException (util.js:734:11)
    at spawnSync (child_process.js:1300:20)
    at execSync (child_process.js:1355:13)
    at Command.execSync (.../node_modules/gitty/lib/command.js:46:10)
    at Repository.statusSync (.../node_modules/gitty/lib/repository.js:148:50)
    at Object.<anonymous> (.../test.js:5:18)
    at Module._compile (module.js:446:26)
    at Object.Module._extensions..js (module.js:464:10)
    at Module.load (module.js:341:32)
    at Function.Module._load (module.js:296:12)
```