### PR TITLE
Fixes quotes in commit messages failing to parse

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -14,12 +14,16 @@ parsers.log = function(output) {
 
   // this function cleans the commit log from any double quotes breaking the
   // JSON string
-  var h = log.match(/".*?": "(.*?)"[,}]/g);
+
+    var jsonValueRegex = /".*?":"(.*?)"[,}]/g;
+
+  var h = log.match(jsonValueRegex);
 
   if (h) {
+
     for (var i = h.length - 1; i >= 0; i--) {
-      var hh = h[i].replace(/".*?": "(.*?)"[,}]/g, '$1');
-      var hhh = hh.replace(/\"/g, '\\"');
+      var hh = h[i].replace(jsonValueRegex, '$1');
+      var hhh = hh.replace(/\"/g, '\\"').replace(/\'/g, "\\'");
 
       log = log.replace(hh, hhh);
     }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -23,7 +23,7 @@ parsers.log = function(output) {
 
     for (var i = h.length - 1; i >= 0; i--) {
       var hh = h[i].replace(jsonValueRegex, '$1');
-      var hhh = hh.replace(/\"/g, '\\"').replace(/\'/g, "\\'");
+      var hhh = hh.replace(/\"/g, '\\"').replace(/\'/g, "");
 
       log = log.replace(hh, hhh);
     }

--- a/test/repository.integration.js
+++ b/test/repository.integration.js
@@ -163,6 +163,25 @@ describe('Repository', function() {
       });
     });
 
+    it('should be able to parse commit messages with quotation marks', function(done) {
+
+        //add a file so something can be committed
+        fs.writeFileSync(repo1.path + '/testFile.txt', 'i am a file');
+        repo1.addSync(['testFile.txt']);
+
+        var commitMessage = "this commit shouldn't fail due to apostrophe, or \"quotation marks";
+
+        repo1.commitSync(commitMessage.replace(/\"/g, '\\"').replace(/\'/g, "\\'"));
+
+        repo1.log(function(err, log) {
+            should.not.exist(err);
+            log.should.have.lengthOf(2);
+            repo1.resetSync(log[1].commit); //reset the commit
+            done();
+        });
+
+    });
+
   });
 
   describe('.logSync()', function() {


### PR DESCRIPTION
Fixed regex code duplication for cleaning json commit log, fixed space in regex that was causing it to not match, added added integration test to assert quotation marks are ok to be parsed in git log.

Fixes #32