### PR TITLE
Passing Repository to Command to allow access to path and gitpath fields.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ constructor, and below is how you might do it. In `lib/repository.js`:
 // we want to pass a branch name and callback into this method
 Repository.prototype.createBranchAndCheckout = function(name, callback) {
   var self = this;
-  var cmd  = new Command(self.path, 'checkout', ['-b'], name);
+  var cmd  = new Command(self, 'checkout', ['-b'], name);
 
   cmd.exec(function(error, stdout, stderr) {
     callback(error || stderr || null);
@@ -76,7 +76,7 @@ for Gitty).
 // we want to pass a branch name and callback into this method
 Repository.prototype.createBranchAndCheckoutSync = function(name, callback) {
   var self = this
-  var cmd  = new Command(self.path, 'checkout', ['-b'], name);
+  var cmd  = new Command(self, 'checkout', ['-b'], name);
 
   return cmd.execSync();
 };

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var Gitty = function(path) {
 * @param {function} callback
 */
 Gitty.setConfig = function(key, val, callback) {
-  var cmd = new Command('/', 'config', ['--global', key], '"' + val + '"');
+  var cmd = new Command(null, 'config', ['--global', key], '"' + val + '"');
   var done = callback || new Function();
 
   cmd.exec(function(err, stdout, stderr) {
@@ -36,7 +36,7 @@ Gitty.setConfig = function(key, val, callback) {
 * @param {function} callback
 */
 Gitty.setConfigSync = function(key, val) {
-  var cmd = new Command('/', 'config', ['--global', key], '"' + val + '"');
+  var cmd = new Command(null, 'config', ['--global', key], '"' + val + '"');
 
   return cmd.execSync();
 };
@@ -47,7 +47,7 @@ Gitty.setConfigSync = function(key, val) {
 * @param {function} callback
 */
 Gitty.getConfig = function(key, callback) {
-  var cmd = new Command('/', 'config', ['--global', key]);
+  var cmd = new Command(null, 'config', ['--global', key]);
   var done = callback || new Function();
 
   cmd.exec(function(err, stdout, stderr) {
@@ -61,7 +61,7 @@ Gitty.getConfig = function(key, callback) {
 * @param {function} callback
 */
 Gitty.getConfigSync = function(key) {
-  var cmd = new Command('/', 'config', ['--global', key]);
+  var cmd = new Command(null, 'config', ['--global', key]);
 
   return cmd.execSync();
 };
@@ -78,7 +78,7 @@ Gitty.clone = function(path, url) {
   var args = Array.prototype.slice.apply(arguments);
   var creds = args[2].username ? args[2] : {};
   var done = args.slice(-1).pop() || new Function();
-  var clone = new Command('/', 'clone', [url, path]);
+  var clone = new Command(null, 'clone', [url, path]);
   var error = null;
 
   clone.exec(function(err, stdout, stderr) {

--- a/index.js
+++ b/index.js
@@ -9,9 +9,10 @@ var Command = require('./lib/command');
 * Setup function for getting access to a GIT repo
 * @constructor
 * @param {string} path
+* @param {string} [gitpath]
 */
-var Gitty = function(path) {
-  return new Repository(path);
+var Gitty = function(path, gitpath) {
+  return new Repository(path, gitpath);
 };
 
 /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -9,18 +9,23 @@ var execSync = childproc.execSync;
 /**
 * Setup function for running GIT commands on the command line
 * @constructor
-* @param {string} path
+* @param {Repository} repo
 * @param {string} operation
 * @param {array}  flags
 * @param {string} options
 */
-var Command = function(path, operation, flags, options) {
+var Command = function(repo, operation, flags, options) {
   flags = flags || [];
   options = options || '';
   var largeOperations = ['log', 'ls-files'];
 
-  this.repo = path;
-  this.command = 'git ' + operation + ' ' + flags.join(' ') + ' ' + options;
+  if (typeof repo === 'string') {
+    this.repo = { path: repo, gitpath: '' };
+  } else {
+    this.repo = repo || { path: '/', gitpath: '' };
+  }
+  this.command = (this.repo.gitpath ? this.repo.gitpath + ' ' : 'git ') + 
+    operation + ' ' + flags.join(' ') + ' ' + options;
   // The log on long lived active repos will require more stdout buffer.
   // The default (200K) seems sufficient for all other operations.
   this.execBuffer = 1024 * 200;
@@ -44,7 +49,7 @@ Command.prototype.exec = function(callback) {
 * #execSync
 */
 Command.prototype.execSync = function() {
-  process.chdir(this.repo);
+  process.chdir(this.repo.path);
   return execSync(this.command, this._getExecOptions()).toString();
 };
 
@@ -54,7 +59,7 @@ Command.prototype.execSync = function() {
 */
 Command.prototype._getExecOptions = function() {
   return {
-    cwd: this.repo,
+    cwd: this.repo.path,
     maxBuffer: this.execBuffer
   };
 };

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -15,6 +15,7 @@ var logFmt = '--pretty=format:\'{"commit":"%H","author":"%an <%ae>",' +
 * Constructor function for all repository commands
 * @constructor
 * @param {string} repo
+* @param {string} gitpath
 */
 var Repository = function(repo, gitpath) {
   var self = this;

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -16,11 +16,12 @@ var logFmt = '--pretty=format:\'{"commit":"%H","author":"%an <%ae>",' +
 * @constructor
 * @param {string} repo
 */
-var Repository = function(repo) {
+var Repository = function(repo, gitpath) {
   var self = this;
 
   events.EventEmitter.call(this);
 
+  self.gitpath = gitpath ? path.normalize(gitpath) : '';
   self.path = path.normalize(repo);
   self._ready = false;
   self.name = path.basename(self.path);
@@ -46,7 +47,7 @@ Repository.prototype.init = function() {
   var args = Array.prototype.slice.apply(arguments);
   var flags = Array.isArray(args[0]) ? args[0] : [];
   var done = args.slice(-1).pop() || function() { };
-  var cmd = new Command(self.path, 'init', flags, '');
+  var cmd = new Command(self, 'init', flags, '');
 
   cmd.exec(function(err, stdout, stderr) {
     if (err) {
@@ -69,7 +70,7 @@ Repository.prototype.initSync = function() {
   var self = this;
   var args = Array.prototype.slice.apply(arguments);
   var flags = Array.isArray(args[0]) ? args[0] : [];
-  var cmd = new Command(self.path, 'init', flags, '');
+  var cmd = new Command(self, 'init', flags, '');
 
   cmd.execSync();
 
@@ -87,7 +88,7 @@ Repository.prototype.log = function() {
   var args = Array.prototype.slice.apply(arguments);
   var path = typeof args[0] === 'string' ? args[0] : '';
   var done = args.slice(-1).pop() || function() { };
-  var cmd = new Command(self.path, 'log', [logFmt, path]);
+  var cmd = new Command(self, 'log', [logFmt, path]);
 
   cmd.exec(function(err, stdout, stderr) {
     if (err || stderr) {
@@ -105,7 +106,7 @@ Repository.prototype.log = function() {
 */
 Repository.prototype.logSync = function(branch) {
   var self = this;
-  var cmd = new Command(self.path, 'log', [logFmt, branch || '']);
+  var cmd = new Command(self, 'log', [logFmt, branch || '']);
 
   return parse.log(cmd.execSync());
 };
@@ -121,8 +122,8 @@ Repository.prototype.status = function() {
   var args = Array.prototype.slice.apply(arguments);
   var done = args.slice(-1).pop() || function() { };
   var flags = Array.isArray(args[0]) ? args[0] : [];
-  var status = new Command(self.path, 'status', flags);
-  var lsFiles = new Command(self.path, 'ls-files', ['-o','--exclude-standard']);
+  var status = new Command(self, 'status', flags);
+  var lsFiles = new Command(self, 'ls-files', ['-o','--exclude-standard']);
 
   status.exec(function(err, status, stderr) {
     if (err) {
@@ -146,8 +147,8 @@ Repository.prototype.status = function() {
 */
 Repository.prototype.statusSync = function(flags) {
   var self = this;
-  var status = new Command(self.path, 'status', flags);
-  var lsFiles = new Command(self.path, 'ls-files', ['-o','--exclude-standard']);
+  var status = new Command(self, 'status', flags);
+  var lsFiles = new Command(self, 'ls-files', ['-o','--exclude-standard']);
 
   return parse.status(status.execSync(), lsFiles.execSync());
 };
@@ -165,7 +166,7 @@ Repository.prototype.add = function() {
   var files = args[0];
   var done = args.slice(-1).pop() || function() { };
   var flags = Array.isArray(args[1]) ? args[1] : [];
-  var cmd = new Command(self.path, 'add', flags, files.join(' '));
+  var cmd = new Command(self, 'add', flags, files.join(' '));
 
   cmd.exec(function(err, stdout, stderr) {
     if (err) {
@@ -184,7 +185,7 @@ Repository.prototype.add = function() {
 */
 Repository.prototype.addSync = function(files, flags) {
   var self = this;
-  var cmd = new Command(self.path, 'add', flags || [], files.join(' '));
+  var cmd = new Command(self, 'add', flags || [], files.join(' '));
 
   return cmd.execSync();
 };
@@ -201,7 +202,7 @@ Repository.prototype.remove = function() {
   var files = args[0];
   var done = args.slice(-1).pop() || function() { };
   var flags = Array.isArray(args[1]) ? args[1] : ['--cached'];
-  var cmd = new Command(self.path, 'rm', flags, files.join(' '));
+  var cmd = new Command(self, 'rm', flags, files.join(' '));
 
   cmd.exec(function(err, stdout, stderr) {
     if (err) {
@@ -220,7 +221,7 @@ Repository.prototype.remove = function() {
 */
 Repository.prototype.removeSync = function(files, flags) {
   var self = this;
-  var cmd = new Command(self.path, 'rm', flags || ['--cached'], files.join(' '));
+  var cmd = new Command(self, 'rm', flags || ['--cached'], files.join(' '));
 
   return cmd.execSync();
 };
@@ -238,7 +239,7 @@ Repository.prototype.unstage = function() {
   var files = args[0];
   var done = args.slice(-1).pop() || function() { };
   var flags = Array.isArray(args[1]) ? args[1] : [];
-  var cmd = new Command(self.path, 'reset HEAD', flags, files.join(' '));
+  var cmd = new Command(self, 'reset HEAD', flags, files.join(' '));
 
   cmd.exec(function(err, stdout, stderr) {
     if (err) {
@@ -257,7 +258,7 @@ Repository.prototype.unstage = function() {
 */
 Repository.prototype.unstageSync = function(files, flags) {
   var self = this;
-  var cmd = new Command(self.path, 'reset HEAD', flags || [], files.join(' '));
+  var cmd = new Command(self, 'reset HEAD', flags || [], files.join(' '));
 
   return cmd.execSync();
 };
@@ -274,7 +275,7 @@ Repository.prototype.commit = function() {
   var message = args[0];
   var done = args.slice(-1).pop() || function() { };
   var flags = Array.isArray(args[1]) ? args[1].push('-m') : ['-m'];
-  var cmd = new Command(this.path, 'commit', flags, '"' + message + '"');
+  var cmd = new Command(this, 'commit', flags, '"' + message + '"');
 
   cmd.exec(function(err, stdout, stderr) {
     if (err) {
@@ -300,7 +301,7 @@ Repository.prototype.commit = function() {
 Repository.prototype.commitSync = function(message, flags) {
   var self = this;
   flags = Array.isArray(flags) ? flags.push('-m') : ['-m'];
-  var cmd = new Command(this.path, 'commit', flags, '"' + message + '"');
+  var cmd = new Command(this, 'commit', flags, '"' + message + '"');
   var output = cmd.execSync();
   var result = output ? parse.commit(output) : {};
 
@@ -319,7 +320,7 @@ Repository.prototype.commitSync = function(message, flags) {
 Repository.prototype.getBranches = function(callback) {
   var self = this;
   var done = callback || function() { };
-  var cmd = new Command(self.path, 'branch');
+  var cmd = new Command(self, 'branch');
 
   cmd.exec(function(err, stdout, stderr) {
     if (err) {
@@ -337,7 +338,7 @@ Repository.prototype.getBranches = function(callback) {
 */
 Repository.prototype.getBranchesSync = function() {
   var self = this;
-  var cmd = new Command(self.path, 'branch');
+  var cmd = new Command(self, 'branch');
 
   return parse.branch(cmd.execSync());
 };
@@ -355,7 +356,7 @@ Repository.prototype.createBranch = function() {
   var name = args[0];
   var done = args.slice(-1).pop() || function() { };
   var flags = Array.isArray(args[1]) ? args[1] : [];
-  var cmd = new Command(self.path, 'branch', flags, name);
+  var cmd = new Command(self, 'branch', flags, name);
 
   cmd.exec(function(err, stdout, stderr) {
     if (err) {
@@ -374,7 +375,7 @@ Repository.prototype.createBranch = function() {
 */
 Repository.prototype.createBranchSync = function(name, flags) {
   var self = this;
-  var cmd = new Command(self.path, 'branch', flags || [], name);
+  var cmd = new Command(self, 'branch', flags || [], name);
 
   return cmd.execSync();
 };
@@ -392,7 +393,7 @@ Repository.prototype.checkout = function() {
   var branch = args[0];
   var done = args.slice(-1).pop() || function() { };
   var flags = Array.isArray(args[1]) ? args[1] : [];
-  var cmd = new Command(self.path, 'checkout', flags, branch);
+  var cmd = new Command(self, 'checkout', flags, branch);
 
   cmd.exec(function(err, stdout, stderr) {
     if (err) {
@@ -411,7 +412,7 @@ Repository.prototype.checkout = function() {
 */
 Repository.prototype.checkoutSync = function(branch, flags) {
   var self = this;
-  var cmd = new Command(self.path, 'checkout', flags || [], branch);
+  var cmd = new Command(self, 'checkout', flags || [], branch);
 
   cmd.execSync();
 
@@ -431,7 +432,7 @@ Repository.prototype.merge = function() {
   var branch = args[0];
   var done = args.slice(-1).pop() || function() { };
   var flags = Array.isArray(args[1]) ? args[1] : [];
-  var cmd = new Command(self.path, 'merge', flags, branch);
+  var cmd = new Command(self, 'merge', flags, branch);
 
   cmd.exec(function(err, stdout, stderr) {
     if (err) {
@@ -449,7 +450,7 @@ Repository.prototype.merge = function() {
 */
 Repository.prototype.mergeSync = function(branch, flags) {
   var self = this;
-  var cmd = new Command(self.path, 'merge', flags || [], branch);
+  var cmd = new Command(self, 'merge', flags || [], branch);
 
   return cmd.execSync();
 };
@@ -462,7 +463,7 @@ Repository.prototype.mergeSync = function(branch, flags) {
 Repository.prototype.getTags = function(callback) {
   var self = this;
   var done = callback || function() { };
-  var cmd = new Command(self.path, 'tag');
+  var cmd = new Command(self, 'tag');
 
   cmd.exec(function(err, stdout, stderr) {
     if (err) {
@@ -479,7 +480,7 @@ Repository.prototype.getTags = function(callback) {
 */
 Repository.prototype.getTagsSync = function() {
   var self = this;
-  var cmd = new Command(self.path, 'tag');
+  var cmd = new Command(self, 'tag');
 
   return parse.tag(cmd.execSync());
 };
@@ -497,7 +498,7 @@ Repository.prototype.createTag = function() {
   var name = args[0];
   var done = args.slice(-1).pop() || function() { };
   var flags = Array.isArray(args[1]) ? args[1] : [];
-  var cmd = new Command(self.path, 'tag', flags, name);
+  var cmd = new Command(self, 'tag', flags, name);
 
   cmd.exec(function(err, stdout, stderr) {
     if (err) {
@@ -516,7 +517,7 @@ Repository.prototype.createTag = function() {
 */
 Repository.prototype.createTagSync = function(name, flags) {
   var self = this;
-  var cmd = new Command(self.path, 'tag', flags || [], name);
+  var cmd = new Command(self, 'tag', flags || [], name);
 
   return cmd.execSync();
 };
@@ -536,7 +537,7 @@ Repository.prototype.addRemote = function() {
   var url = args[1];
   var done = args.slice(-1).pop() || function() { };
   var flags = Array.isArray(args[2]) ? args[2] : [];
-  var cmd = new Command(self.path, 'remote add', flags, remote + ' ' + url);
+  var cmd = new Command(self, 'remote add', flags, remote + ' ' + url);
 
   cmd.exec(function(err, stdout, stderr) {
     if (err) {
@@ -556,7 +557,7 @@ Repository.prototype.addRemote = function() {
 */
 Repository.prototype.addRemoteSync = function(remote, url, flags) {
   var self = this;
-  var cmd = new Command(self.path, 'remote add', flags || [], remote + ' ' + url);
+  var cmd = new Command(self, 'remote add', flags || [], remote + ' ' + url);
 
   return cmd.execSync();
 };
@@ -576,7 +577,7 @@ Repository.prototype.setRemoteUrl = function() {
   var url = args[1];
   var done = args.slice(-1).pop() || function() { };
   var flags = Array.isArray(args[2]) ? args[2] : [];
-  var cmd = new Command(self.path, 'remote set-url', flags, remote + ' ' + url);
+  var cmd = new Command(self, 'remote set-url', flags, remote + ' ' + url);
 
   cmd.exec(function(err, stdout, stderr) {
     if (err) {
@@ -597,7 +598,7 @@ Repository.prototype.setRemoteUrl = function() {
 */
 Repository.prototype.setRemoteUrlSync = function(remote, url, flags) {
   var self = this;
-  var cmd = new Command(self.path, 'remote set-url', flags || [], remote + ' ' + url);
+  var cmd = new Command(self, 'remote set-url', flags || [], remote + ' ' + url);
 
   return cmd.execSync();
 };
@@ -615,7 +616,7 @@ Repository.prototype.removeRemote = function() {
   var remote = args[0];
   var done = args.slice(-1).pop() || function() { };
   var flags = Array.isArray(args[1]) ? args[1] : [];
-  var cmd = new Command(self.path, 'remote rm', flags, remote);
+  var cmd = new Command(self, 'remote rm', flags, remote);
 
   cmd.exec(function(err, stdout, stderr) {
     if (err) {
@@ -634,7 +635,7 @@ Repository.prototype.removeRemote = function() {
 */
 Repository.prototype.removeRemoteSync = function(remote, flags) {
   var self = this;
-  var cmd = new Command(self.path, 'remote rm', flags || [], remote);
+  var cmd = new Command(self, 'remote rm', flags || [], remote);
 
   return cmd.execSync();
 };
@@ -647,7 +648,7 @@ Repository.prototype.removeRemoteSync = function(remote, flags) {
 Repository.prototype.getRemotes = function(callback) {
   var self = this;
   var done = callback || function() { };
-  var cmd = new Command(self.path, 'remote', ['-v']);
+  var cmd = new Command(self, 'remote', ['-v']);
 
   cmd.exec(function(err, stdout, stderr) {
     if (err) {
@@ -665,7 +666,7 @@ Repository.prototype.getRemotes = function(callback) {
 */
 Repository.prototype.getRemotesSync = function() {
   var self = this;
-  var cmd = new Command(self.path, 'remote', ['-v']);
+  var cmd = new Command(self, 'remote', ['-v']);
 
   return parse.remotes(cmd.execSync());
 };
@@ -695,7 +696,7 @@ Repository.prototype.push = function() {
     creds = args[2];
   }
 
-  return sync(self.path, {
+  return sync(self, {
     operation: 'push',
     remote: remote,
     branch: branch,
@@ -729,7 +730,7 @@ Repository.prototype.pull = function() {
     creds = args[2];
   }
 
-  return sync(this.path, {
+  return sync(this, {
     operation: 'pull',
     remote: remote,
     branch: branch,
@@ -743,13 +744,13 @@ Repository.prototype.pull = function() {
 * @param {object} options
 * @param {function} callback
 */
-function sync(path, opts, callback) {
+function sync(repo, opts, callback) {
   var self = this;
   var done = callback || function() { };
   var flags = opts.flags || [];
   var creds = opts.credentials;
   var options = [opts.remote, opts.branch].concat(flags);
-  var cmd = new Command(path, opts.operation, options);
+  var cmd = new Command(repo, opts.operation, options);
 
   cmd.exec(function(err, stdout, stderr) {
     done(err);
@@ -765,7 +766,7 @@ function sync(path, opts, callback) {
 Repository.prototype.reset = function(hash, callback) {
   var self = this;
   var done = callback || function() { };
-  var cmd = new Command(self.path, 'reset', ['--hard'], hash);
+  var cmd = new Command(self, 'reset', ['--hard'], hash);
 
   cmd.exec(function(err, stdout, stderr) {
     if (err) {
@@ -789,7 +790,7 @@ Repository.prototype.reset = function(hash, callback) {
 */
 Repository.prototype.resetSync = function(hash) {
   var self = this;
-  var cmd = new Command(self.path, 'reset', ['--hard'], hash);
+  var cmd = new Command(self, 'reset', ['--hard'], hash);
 
   cmd.execSync();
 
@@ -804,7 +805,7 @@ Repository.prototype.resetSync = function(hash) {
 Repository.prototype.describe = function(callback) {
   var self = this;
   var done = callback || function() { };
-  var cmd = new Command(self.path, 'describe', ['--always']);
+  var cmd = new Command(self, 'describe', ['--always']);
 
   cmd.exec(function(err, stdout, stderr) {
     if (err) {
@@ -821,7 +822,7 @@ Repository.prototype.describe = function(callback) {
 */
 Repository.prototype.describeSync = function() {
   var self = this;
-  var cmd = new Command(self.path, 'describe', ['--always']);
+  var cmd = new Command(self, 'describe', ['--always']);
 
   return cmd.execSync();
 };
@@ -838,7 +839,7 @@ Repository.prototype.cherryPick = function() {
   var commit = args[0];
   var done = args.slice(-1).pop() || function() { };
   var flags = Array.isArray(args[1]) ? args[1] : [];
-  var cmd  = new Command(self.path, 'cherry-pick', flags, commit);
+  var cmd  = new Command(self, 'cherry-pick', flags, commit);
 
   cmd.exec(function(err, stdout, stderr) {
     if (err) {
@@ -858,7 +859,7 @@ Repository.prototype.cherryPick = function() {
 */
 Repository.prototype.cherryPickSync = function(commit, flags) {
   var self = this;
-  var cmd = new Command(self.path, 'cherry-pick', flags || [], commit);
+  var cmd = new Command(self, 'cherry-pick', flags || [], commit);
 
   return cmd.execSync();
 };
@@ -874,7 +875,7 @@ Repository.prototype.show = function(commit, filePath, callback) {
   var self = this;
   var done = callback || function() { };
   var revision = commit + ':' + filePath;
-  var cmd  = new Command(self.path, 'show', [], revision);
+  var cmd  = new Command(self, 'show', [], revision);
 
   cmd.exec(function(err, stdout, stderr) {
     if (err) {
@@ -893,7 +894,7 @@ Repository.prototype.show = function(commit, filePath, callback) {
 Repository.prototype.showSync = function(commit, filePath) {
   var self = this;
   var revision = commit + ':' + filePath;
-  var cmd = new Command(self.path, 'show', [], revision);
+  var cmd = new Command(self, 'show', [], revision);
 
   return cmd.execSync();
 };

--- a/package.json
+++ b/package.json
@@ -84,6 +84,10 @@
     {
       "name": "James Birkett",
       "url": "https://github.com/jamesbirkett"
+    },
+    {
+      "name": "Wayne Bloss",
+      "url": "https://github.com/waynebloss"
     }
   ],
   "license": "LGPLv3"

--- a/test/command.unit.js
+++ b/test/command.unit.js
@@ -15,7 +15,7 @@ describe('Command', function() {
     });
 
     it('should save the working path', function(done) {
-      command.repo.should.equal(HOME);
+      command.repo.path.should.equal(HOME);
       done();
     });
 


### PR DESCRIPTION
Here are the changes that I discussed in issue #51.

Some known issues:

- The JsDoc info on [this line](https://github.com/gordonwritescode/gitty/compare/master...waynebloss:master#diff-b26080cc6f2472dce354dbedffc64d57R12) is not complete. It should be changed to `{string|Repository}` at the least I think.

- All tests passed for me except for the clone test because I have no git server running. I could change the url and test again I guess but I didn't want to waste any time figuring it out since you will most likely run tests yourself.

Thanks. Let me know if there is anything that you do not like.