### PR TITLE
Fix issue when running log() command on Windows.

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -9,7 +9,11 @@ var Command = require('./command');
 var parse = require('./parser');
 var events = require('events');
 var logFmt = '--pretty=format:\'{"commit":"%H","author":"%an <%ae>",' +
-             '"date":"%ad","message":"%s"},\'';
+             '"date":"%ad","message":"%s"}\',';
+if (require('os').platform() === 'win32') {
+	logFmt = '--pretty=format:{\\"commit\\":\\""%H"\\",\\"author\\":\\""%an ^<%ae^>"\\",' +
+             '\\"date\\":\\"%ad\\",\\"message\\":\\"%s\\"},';
+}
 
 /**
 * Constructor function for all repository commands


### PR DESCRIPTION
This change addresses an issue with using the log() command in a Windows environment. Due to shell differences the existing underlying call to git log was producing different output on Windows vs Unix. This meant that the output on Windows wasn't valid JSON and the caused the JSON parsing to fail.

I've added a new logFmt specification for Windows and tested it to confirm that it produces the same output as the original logFmt specification does in Unix environments.

I believe this addresses issue #49 as it mentions a single quote character at the beginning of each log line and that is one of the systems we saw on Windows with the original logFmt specification. The issue doesn't mention Windows though so it's hard to absolutely confirm this.

I wasn't able to get the tests to run successfully on Windows but I believe this is due to some pre-existing Windows compatibility issues with the tests. Note that the log-specific tests work fine on Windows and the complete suite (as expected) works fine with the changes on Ubuntu.

Cheers,
Simon