### PR TITLE
Allow push without a callback.

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -697,7 +697,7 @@ Repository.prototype.push = function() {
   if (flags && args[3].username) {
     creds = args[3];
   }
-  else if (args[2].username) {
+  else if (args[2] && args[2].username) {
     creds = args[2];
   }
 


### PR DESCRIPTION
Handles the case where arg[2] is undefined or null.

Addresses issue #54.